### PR TITLE
Execute SuperCollider code in sclang repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ which are used to send chunks of TidalCycles code from the file to the Tidal int
 vim.api.nvim_create_user_command("InstantGabber", function()
   local tidal = require("tidal")
   --- Send a message to tidal
-  tidal.api.send("setcps (200/60/4)")
+  --- second parameter 'tc' to send to tidal cycles repl, 'sc' for SuperCollider repl
+  tidal.api.send("setcps (200/60/4)", 'tc')
   --- Send a multiline message to tidal
   local drums = {
     "d1 $ stack [",
@@ -135,9 +136,9 @@ vim.api.nvim_create_user_command("InstantGabber", function()
     's "<[~ sd:2]*4!3 [sd*4 [~ sd]!3]>",',
     's "~ hh:2*4"]',
   }
-  tidal.api.send_multiline(drums)
-  tidal.api.send('d2 $ "amencutup*8" # irand 32 # crush 4 # speed (5/4)')
-  tidal.api.send('d3 $ s "rave" + speed "[3 2 3 2] [4 3 4 2]" # end (slow 2 (tri * 0.7))')
+  tidal.api.send_multiline(drums, 'tc')
+  tidal.api.send('d2 $ "amencutup*8" # irand 32 # crush 4 # speed (5/4)', 'tc')
+  tidal.api.send('d3 $ s "rave" + speed "[3 2 3 2] [4 3 4 2]" # end (slow 2 (tri * 0.7))', 'tc')
 end, { desc = "Make gabber happen fast" })
 ```
 

--- a/lua/tidal/api.lua
+++ b/lua/tidal/api.lua
@@ -59,7 +59,7 @@ M.send = message.send
 
 -- Send 'd{count} silence' to tidal interpreter to silence a pattern d1-d16
 M.send_silence = function()
-  message.send(string.format("d%d silence", vim.v.count1))
+  message.send(string.format("d%d silence", vim.v.count1), 'tc')
 end
 
 M.send_multiline = message.send_multiline

--- a/lua/tidal/config.lua
+++ b/lua/tidal/config.lua
@@ -8,6 +8,7 @@ local M = {}
 ---@class TidalProcConfig
 ---@field cmd string
 ---@field file string
+---@field glob string
 ---@field args table<string>
 ---@field enabled boolean
 
@@ -30,6 +31,7 @@ local defaults = {
       cmd = "sclang",
       args = {},
       --- SuperCollider boot file
+      glob = 'BootSuperDirt.scd',
       file = vim.api.nvim_get_runtime_file("bootfiles/BootSuperDirt.scd", false)[1],
       enabled = false,
     },

--- a/lua/tidal/core/boot.lua
+++ b/lua/tidal/core/boot.lua
@@ -1,3 +1,4 @@
+local message = require("tidal.core.message")
 local state = require("tidal.core.state")
 local scd = require("tidal.util.scd")
 
@@ -73,7 +74,7 @@ function M.sclang(args)
   else
     return
   end
-  vim.api.nvim_chan_send(state.sclang.proc, scd.scd_concat(lines) .. "\n")
+  message.send_multiline(lines, 'sc')
 end
 
 return M

--- a/lua/tidal/core/boot.lua
+++ b/lua/tidal/core/boot.lua
@@ -1,4 +1,5 @@
 local state = require("tidal.core.state")
+local scd = require("tidal.util.scd")
 
 local M = {}
 
@@ -53,7 +54,7 @@ function M.sclang(args)
     return
   end
 
-  state.sclang.proc = vim.fn.termopen(args.cmd .. " " .. args.file, {
+  state.sclang.proc = vim.fn.termopen(args.cmd, {
     on_exit = function()
       if state.sclang.buf ~= nil and #vim.fn.win_findbuf(state.sclang.buf) > 0 then
         vim.api.nvim_win_close(vim.fn.win_findbuf(state.sclang.buf)[1], true)
@@ -63,6 +64,16 @@ function M.sclang(args)
       state.sclang.proc = nil
     end,
   })
+
+  local lines;
+  if scd.file_exists(args.glob) then
+    lines = scd.lines_from(args.glob)
+  elseif scd.file_exists(args.file) then
+    lines = scd.lines_from(args.file)
+  else
+    return
+  end
+  vim.api.nvim_chan_send(state.sclang.proc, scd.scd_concat(lines) .. "\n")
 end
 
 return M

--- a/lua/tidal/core/message.lua
+++ b/lua/tidal/core/message.lua
@@ -7,10 +7,20 @@ local M = {}
 --- Send a command to the tidal interpreter
 ---@param text string
 function M.send(text)
-  if not state.ghci.proc then
-    return
+  local buf = vim.api.nvim_get_current_buf()
+  local ftype = vim.api.nvim_get_option_value('filetype', { buf = buf })
+
+  if ftype == 'haskell' then
+    if not state.ghci.proc then
+      return
+    end
+    vim.api.nvim_chan_send(state.ghci.proc, text .. "\n")
+  elseif ftype == 'supercollider' then
+    if not state.sclang.proc then
+      return
+    end
+    vim.api.nvim_chan_send(state.sclang.proc, text .. "\n")
   end
-  vim.api.nvim_chan_send(state.ghci.proc, text .. "\n")
 end
 
 --- Send a multiline command to the tidal interpreter

--- a/lua/tidal/core/message.lua
+++ b/lua/tidal/core/message.lua
@@ -5,9 +5,10 @@ local scd = require("tidal.util.scd")
 local M = {}
 
 --- Send a command to the tidal interpreter
----@param text string
-function M.send(text)
-  local _, proc = scd.filetype()
+--- @param text string
+--- @param repl "tc" | "sc" | nil
+function M.send(text, --[[optional]]repl)
+  local _, proc = scd.filetype(repl)
 
   if not proc then
     return
@@ -17,14 +18,15 @@ function M.send(text)
 end
 
 --- Send a multiline command to the tidal interpreter
----@param lines string[]
-function M.send_multiline(lines)
-  local ftype, _ =  scd.filetype()
+--- @param lines string[]
+--- @param repl "tc" | "sc" | nil
+function M.send_multiline(lines, --[[optional]]repl)
+  local ftype, _ =  scd.filetype(repl)
 
-  if ftype == 'haskell' then
-    M.send(":{\n" .. table.concat(lines, "\n") .. "\n:}")
-  elseif ftype == 'supercollider' then
-    M.send(scd.scd_concat(lines))
+  if ftype == 'tc' then
+    M.send(":{\n" .. table.concat(lines, "\n") .. "\n:}", repl)
+  elseif ftype == 'sc' then
+    M.send(scd.scd_concat(lines), repl)
   end
 end
 

--- a/lua/tidal/init.lua
+++ b/lua/tidal/init.lua
@@ -34,7 +34,22 @@ local function setup_autocmds()
     group = "Tidal",
     pattern = { "*.tidal" },
     callback = function()
-      vim.api.nvim_buf_set_option(0, "filetype", "haskell")
+      local buf = vim.api.nvim_get_current_buf()
+      vim.api.nvim_set_option_value('filetype', 'haskell', { buf = buf })
+      for name, mapping in pairs(config.options.mappings or {}) do
+        if mapping then
+          local command = keymaps[name]
+          vim.keymap.set(mapping.mode, mapping.key, command.callback, { buffer = true, desc = command.desc })
+        end
+      end
+    end,
+  })
+  vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
+    group = "Tidal",
+    pattern = { "*.scd" },
+    callback = function()
+      local buf = vim.api.nvim_get_current_buf()
+      vim.api.nvim_set_option_value('filetype', 'supercollider', { buf = buf })
       for name, mapping in pairs(config.options.mappings or {}) do
         if mapping then
           local command = keymaps[name]

--- a/lua/tidal/init.lua
+++ b/lua/tidal/init.lua
@@ -15,7 +15,7 @@ local keymaps = {
   send_silence = { callback = api.send_silence, desc = "Send 'd{count} silence' to tidal" },
   send_hush = {
     callback = function()
-      api.send("hush")
+      api.send("hush", 'tc')
     end,
     desc = "Send 'hush' to tidal",
   },

--- a/lua/tidal/util/scd.lua
+++ b/lua/tidal/util/scd.lua
@@ -34,24 +34,29 @@ function M.scd_concat(lines)
   for k,v in pairs(lines) do
     lines[k] = v:gsub('//.*$', '')
   end
-  return table.concat(lines, " "):gsub('/%*.-%*/', '')[1]
+  return table.concat(lines, " "):gsub('/%*.-%*/', '')
 end
 
 --- return the current filetype and matching repl's proc
+--- @param repl "tc" | "sc" | nil
 --- @return string,any
-function M.filetype()
-  local buf = vim.api.nvim_get_current_buf()
-  local ftype = vim.api.nvim_get_option_value('filetype', { buf = buf })
+function M.filetype(repl)
   local proc
 
-  if ftype == 'haskell' then
-    proc = state.ghci.proc
-  elseif ftype == 'supercollider' then
-    proc = state.sclang.proc
+  if not repl then
+    local buf = vim.api.nvim_get_current_buf()
+    repl = vim.api.nvim_get_option_value('filetype', { buf = buf })
   end
 
-  return ftype, proc
+  if repl == 'haskell' or repl == 'tc' then
+    proc = state.ghci.proc
+    repl = 'tc'
+  elseif repl == 'supercollider' or repl == 'sc' then
+    proc = state.sclang.proc
+    repl = 'sc'
+  end
 
+  return repl, proc
 end
 
 return M

--- a/lua/tidal/util/scd.lua
+++ b/lua/tidal/util/scd.lua
@@ -2,14 +2,20 @@ local state = require("tidal.core.state")
 
 local M = {}
 
+
+--- check if file exists
+--- @param file string filename
+--- @return boolean
 function M.file_exists(file)
   local f = io.open(file, "rb")
   if f then f:close() end
   return f ~= nil
 end
 
--- get all lines from a file, returns an empty 
--- list/table if the file does not exist
+--- get all lines from a file, returns an empty 
+--- list/table if the file does not exist
+--- @param file string filename
+--- @return table<string>
 function M.lines_from(file)
   if not M.file_exists(file) then return {} end
   local lines = {}
@@ -19,14 +25,20 @@ function M.lines_from(file)
   return lines
 end
 
+--- concatenates a table of strings
+--- for use with sclang repl
+--- @param lines table<string> table of strings to be concatenated
+--- @return string
 function M.scd_concat(lines)
   --- strip comments
   for k,v in pairs(lines) do
     lines[k] = v:gsub('//.*$', '')
   end
-  return table.concat(lines, " "):gsub('/%*.*%*/', '')
+  return table.concat(lines, " "):gsub('/%*.*%*/', '')[1]
 end
 
+--- return the current filetype and matching repl's proc
+--- @return string,any
 function M.filetype()
   local buf = vim.api.nvim_get_current_buf()
   local ftype = vim.api.nvim_get_option_value('filetype', { buf = buf })

--- a/lua/tidal/util/scd.lua
+++ b/lua/tidal/util/scd.lua
@@ -1,0 +1,45 @@
+local state = require("tidal.core.state")
+
+local M = {}
+
+function M.file_exists(file)
+  local f = io.open(file, "rb")
+  if f then f:close() end
+  return f ~= nil
+end
+
+-- get all lines from a file, returns an empty 
+-- list/table if the file does not exist
+function M.lines_from(file)
+  if not M.file_exists(file) then return {} end
+  local lines = {}
+  for line in io.lines(file) do
+    lines[#lines + 1] = line:gsub('//.*$', '')
+  end
+  return lines
+end
+
+function M.scd_concat(lines)
+  --- strip comments
+  for k,v in pairs(lines) do
+    lines[k] = v:gsub('//.*$', '')
+  end
+  return table.concat(lines, " "):gsub('/%*.*%*/', '')
+end
+
+function M.filetype()
+  local buf = vim.api.nvim_get_current_buf()
+  local ftype = vim.api.nvim_get_option_value('filetype', { buf = buf })
+  local proc
+
+  if ftype == 'haskell' then
+    proc = state.ghci.proc
+  elseif ftype == 'supercollider' then
+    proc = state.sclang.proc
+  end
+
+  return ftype, proc
+
+end
+
+return M

--- a/lua/tidal/util/scd.lua
+++ b/lua/tidal/util/scd.lua
@@ -34,7 +34,7 @@ function M.scd_concat(lines)
   for k,v in pairs(lines) do
     lines[k] = v:gsub('//.*$', '')
   end
-  return table.concat(lines, " "):gsub('/%*.*%*/', '')[1]
+  return table.concat(lines, " "):gsub('/%*.-%*/', '')[1]
 end
 
 --- return the current filetype and matching repl's proc


### PR DESCRIPTION
I tweaked the messages to choose the correct repl by filetype

 boot binds the key mapping in supercollider files
and will init the sclang repl without a file arguemnt to keep the repl interactive

 utils handle file retrieval and formatting for sclang (there is no multiline pasting into the repl, so scd_concat strips comments and packs all text into one line, which works with sclang).

the BootSuperDirt.scd file gets executed using the utils to keep the repl interactive

you can specify boot.sclang.glob to use a file in the current working directory to start SuperDirt (not sure about naming and not strictly necessary, so feel free to tweak this part)