### PR TITLE
fix(readme.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ eg [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 return {
-  "grddavies/tidal.nvim",
-  opts = {
-    -- Your configuration here
-    -- See configuration section for defaults
-  },
-  -- Recommended: Install TreeSitter parsers for Haskell and SuperCollider
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = { ensure_installed = { "haskell", "supercollider" } },
-  },
+	"grddavies/tidal.nvim",
+	opts = {
+		-- Your configuration here
+		-- See configuration section for defaults
+	},
+	-- Recommended: Install TreeSitter parsers for Haskell and SuperCollider
+	dependencies = {
+		"nvim-treesitter/nvim-treesitter",
+		opts = { ensure_installed = { "haskell", "supercollider" } },
+	},
 }
 ```
 


### PR DESCRIPTION
readme lazy install is not working, fix with dependencies
the current README.md had the section:
	-- Recommended: Install TreeSitter parsers for Haskell and SuperCollider
but was missing the dependencies 